### PR TITLE
Fix YAML indent error in fexo theme config

### DIFF
--- a/themes/fexo/_config.yml
+++ b/themes/fexo/_config.yml
@@ -44,8 +44,8 @@ page_nav:
     url: /about
     target_blank: false
   # - name: RSS
-    # url: /atom.xml
-    # target_blank: true # 在新页面打开
+  #   url: /atom.xml
+  #   target_blank: true # 在新页面打开
   # - name: 搜索
   #   url: /search/
   #   target_blank: true # 在新页面打开


### PR DESCRIPTION
修复 themes/fexo/_config.yml 中注释的缩进问题，该问题导致 hexo clean/generate 时出现 YAML 解析错误。

🤖 Generated with [Claude Code](https://claude.com/claude-code)